### PR TITLE
disables JWTFilter for "/posts/approved"

### DIFF
--- a/src/main/java/isuruygor/demo/security/AuthFilter.java
+++ b/src/main/java/isuruygor/demo/security/AuthFilter.java
@@ -65,7 +65,7 @@ public class AuthFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String[] allowedPaths = {"/auth/**", "/posts/categories"};
+        String[] allowedPaths = {"/auth/**", "/posts/categories", "/posts/approved"};
 
         return Stream.of(allowedPaths)
                 .anyMatch(path -> pathMatcher.match(path, request.getServletPath()));


### PR DESCRIPTION
anyone have access even without a token to see all the approved articles